### PR TITLE
Packer 1.7.2 Syntax Update

### DIFF
--- a/win10.base/Win10_vsphere.json
+++ b/win10.base/Win10_vsphere.json
@@ -1,72 +1,64 @@
 {
-
-  
-    "sensitive-variables": ["vsphere_password", "winadmin_password"],
-    
     "builders": [
       {
-        "type": "vsphere-iso",
-  
-        "vcenter_server": "{{user `vsphere-server`}}",
-        "username": "{{user `vsphere-user`}}",
-        "password": "{{user `vsphere-password`}}",
-        "insecure_connection": "true",
-  
-        "datacenter": "{{user `vsphere-datacenter`}}",
-        "cluster": "{{user `vsphere-cluster`}}",
-        "network": "{{user `vsphere-network`}}",
-        "datastore": "{{user `vsphere-datastore`}}",
-        "folder": "{{user `vsphere-folder`}}",
-  
-        "communicator": "winrm",
-        "winrm_use_ssl":"true",
-        "winrm_insecure": "true",
-        "winrm_username": "{{user `winrm_username`}}",
-        "winrm_password": "{{user `winadmin-password`}}",
-  
-        "convert_to_template": "true",
-
-        "vm_name": "{{user `vm-name`}}",
-        "guest_os_type": "windows9_64Guest",
-  
         "CPUs": "{{user `vm-cpu-num`}}",
         "RAM": "{{user `vm-mem-size`}}",
         "RAM_reserve_all": true,
-        "firmware": "bios",
-  
+        "communicator": "winrm",
+        "convert_to_template": "true",
+        "datacenter": "{{user `vsphere-datacenter`}}",
+        "datastore": "{{user `vsphere-datastore`}}",
         "disk_controller_type": "lsilogic-sas",
-        "disk_size": "{{user `vm-disk-size`}}",
-        "disk_thin_provisioned": true,
-  
-        "network_card": "vmxnet3",
-  
+        "firmware": "bios",
+        "floppy_files": [
+          "autounattend.xml",
+          "../scripts/disable-network-discovery.cmd",
+          "../scripts/enable-rdp.cmd",
+          "../scripts/enable-winrm.ps1",
+          "../scripts/install-vm-tools.cmd",
+          "../scripts/set-temp.ps1",
+          "../scripts/microsoft-updates.bat",
+          "../scripts/win-updates.ps1",
+          "../scripts/disable-screensaver.ps1"
+        ],
+        "folder": "{{user `vsphere-folder`}}",
+        "guest_os_type": "windows9_64Guest",
+        "host": "{{user `vsphere-host`}}",
+        "insecure_connection": "true",
         "iso_paths": [
           "{{user `os_iso_path`}}",
           "[] /vmimages/tools-isoimages/windows.iso"
         ],
-  
-        "floppy_files": [
-            "autounattend.xml",
-            "../scripts/disable-network-discovery.cmd",
-            "../scripts/enable-rdp.cmd",
-            "../scripts/enable-winrm.ps1",
-            "../scripts/install-vm-tools.cmd",
-            "../scripts/set-temp.ps1",
-            "../scripts/microsoft-updates.bat",
-            "../scripts/win-updates.ps1",
-            "../scripts/disable-screensaver.ps1"
-        ]
+        "network_adapters": [
+          {
+            "network": "{{user `vsphere-network`}}",
+            "network_card": "vmxnet3"
+          }
+        ],
+        "password": "{{user `vsphere-password`}}",
+        "storage": [
+          {
+            "disk_size": "{{user `vm-disk-size`}}",
+            "disk_thin_provisioned": true
+          }
+        ],
+        "type": "vsphere-iso",
+        "username": "{{user `vsphere-user`}}",
+        "vcenter_server": "{{user `vsphere-server`}}",
+        "vm_name": "{{user `vm-name`}}",
+        "winrm_insecure": "true",
+        "winrm_password": "{{user `winadmin-password`}}",
+        "winrm_use_ssl": "true",
+        "winrm_username": "{{user `winrm_username`}}"
       }
     ],
-        "provisioners": [
-                  
-          {
-            "type": "windows-restart"
-          }
-            
-          
+    "provisioners": [
+      {
+        "type": "windows-restart"
+      }
+    ],
+    "sensitive-variables": [
+      "vsphere_password",
+      "winadmin_password"
     ]
-  
-    
-   
   }


### PR DESCRIPTION
The old syntax of this file does not work without running a "packer fix .\Win10_vsphere.json" on Packer 1.7.2. This commit is the direct output of the packer fix command and successfully created a VM in my vCenter